### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/howboutdatyall/baseline-greenlight/security/code-scanning/1](https://github.com/howboutdatyall/baseline-greenlight/security/code-scanning/1)

To fix this problem, an explicit `permissions` block should be added to the workflow to restrict the GITHUB_TOKEN to the minimum necessary access. Since the example workflow only checks out code and executes some scripts, it requires, at most, read-only access to repository contents. The single best practice is to add a top-level `permissions: contents: read` block after the workflow `name: ...` entry, but before the `jobs:` block. This will apply to all jobs in the workflow unless overridden on a job. No additional keys or changes are required elsewhere, as no steps require more than this permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
